### PR TITLE
Remove unused rules keys from lang files

### DIFF
--- a/java/1_20_6/assets/minecraft/lang/bg_bg.json
+++ b/java/1_20_6/assets/minecraft/lang/bg_bg.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/cs_cz.json
+++ b/java/1_20_6/assets/minecraft/lang/cs_cz.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/da_dk.json
+++ b/java/1_20_6/assets/minecraft/lang/da_dk.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/de_DE.json
+++ b/java/1_20_6/assets/minecraft/lang/de_DE.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ KEIN\u00a7r Hacken oder nutzen von X-Ray-Tools",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ KEIN\u00a7r Zerstören von Häusern/Gegenständen anderer Spieler",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ KEIN\u00a7r Stehlen aus Kisten, die nicht als öffentlich gekennzeichnet sind",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ KEIN\u00a7r anderen Sprachen außer Englisch im globalen Chat",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ KEIN\u00a7r Duplikations-Exploits (außer Sand/Kies mit Kolben)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ KEIN\u00a7r übermäßig sexuellen Kommentare, Rassismus, Sexismus, Homophobie usw.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ KEIN\u00a7r Kriegs-/politischen/(echten)religiösen Gespräche oder Bilder",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ BENUTZE\u00a7r deinen gesunden Menschenverstand und finde ein paar Freunde ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ LASS\u00a7r das echte Leben draußen und genieße das Blockspiel ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/el_gr.json
+++ b/java/1_20_6/assets/minecraft/lang/el_gr.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/en_au.json
+++ b/java/1_20_6/assets/minecraft/lang/en_au.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-
   "addServer.resourcePack": "Server Texture Packs",
   "debug.reload_resourcepacks.help": "F3 + T = Reload texture packs",
   "debug.reload_resourcepacks.message": "Reloaded texture packs",

--- a/java/1_20_6/assets/minecraft/lang/en_ca.json
+++ b/java/1_20_6/assets/minecraft/lang/en_ca.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-
   "addServer.resourcePack": "Server Texture Packs",
   "debug.reload_resourcepacks.help": "F3 + T = Reload texture packs",
   "debug.reload_resourcepacks.message": "Reloaded texture packs",

--- a/java/1_20_6/assets/minecraft/lang/en_gb.json
+++ b/java/1_20_6/assets/minecraft/lang/en_gb.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-
   "addServer.resourcePack": "Server Texture Packs",
   "debug.reload_resourcepacks.help": "F3 + T = Reload texture packs",
   "debug.reload_resourcepacks.message": "Reloaded texture packs",

--- a/java/1_20_6/assets/minecraft/lang/en_nz.json
+++ b/java/1_20_6/assets/minecraft/lang/en_nz.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-
   "addServer.resourcePack": "Server Texture Packs",
   "debug.reload_resourcepacks.help": "F3 + T = Reload texture packs",
   "debug.reload_resourcepacks.message": "Reloaded texture packs",

--- a/java/1_20_6/assets/minecraft/lang/en_us.json
+++ b/java/1_20_6/assets/minecraft/lang/en_us.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel via pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious texts or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-
   "modernbeta.onboarding.take_action.title": "\u00a7c\u00a7lACCEPT RULES IN CHAT",
   "modernbeta.onboarding.take_action.subtitle": "\u00a7cThen you can continue.",
   "modernbeta.onboarding.success.title": "\u00a7a\u00a7lHave fun!",

--- a/java/1_20_6/assets/minecraft/lang/es_mx.json
+++ b/java/1_20_6/assets/minecraft/lang/es_mx.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/fi_fl.json
+++ b/java/1_20_6/assets/minecraft/lang/fi_fl.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/fr_ca.json
+++ b/java/1_20_6/assets/minecraft/lang/fr_ca.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/fr_fr.json
+++ b/java/1_20_6/assets/minecraft/lang/fr_fr.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/hu_HU.json
+++ b/java/1_20_6/assets/minecraft/lang/hu_HU.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NE\u00a7r csalj és ne használj xray-t",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NE\u00a7r rombold mások házát/építményeit/dolgait",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NE\u00a7r lopj mások ládáiból/kemencéiből ha nincs publikusként megjelölve",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NE\u00a7r használj más nyelvet angolon kívül a globális csevegőkben",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NE\u00a7r használj ki semmilyen duplikációt (kivéve a homok/sóder duplikálását dugattyúk használatával)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NINCS\u00a7r helye túlzottan szexuális tartalmú megjegyzéseknek, rasszizmusnak, szexizmusnak, homofóbiának stb.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NE\u00a7r folytassunk háborús/politikai/(valós)vallási témájú beszélgetéseket, és ne osszunk meg ilyen képeket.",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ HASZNÁLD\u00a7r a józan eszed és szerezz néhány barátot ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ HAGYD\u00a7r a valóságot az ajtón kívül és élvezd a játékot ❤",
-
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/id_id.json
+++ b/java/1_20_6/assets/minecraft/lang/id_id.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/it_it.json
+++ b/java/1_20_6/assets/minecraft/lang/it_it.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/ja_jp.json
+++ b/java/1_20_6/assets/minecraft/lang/ja_jp.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/ko_kr.json
+++ b/java/1_20_6/assets/minecraft/lang/ko_kr.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/nb_no.json
+++ b/java/1_20_6/assets/minecraft/lang/nb_no.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/nl_nl.json
+++ b/java/1_20_6/assets/minecraft/lang/nl_nl.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/pl_pl.json
+++ b/java/1_20_6/assets/minecraft/lang/pl_pl.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/pt_BR.json
+++ b/java/1_20_6/assets/minecraft/lang/pt_BR.json
@@ -1,14 +1,4 @@
 {
-    "modernbeta.rules.1": "\u00a7c\u00a7l✖ NÃO\u00a7r utilizar hacks ou raio-x",
-    "modernbeta.rules.2": "\u00a7c\u00a7l✖ NÃO\u00a7r destruir ou danificar as construções de outros jogadores",
-    "modernbeta.rules.3": "\u00a7c\u00a7l✖ NÃO\u00a7r roubar itens de baús que não estejam marcados como públicos",
-    "modernbeta.rules.4": "\u00a7c\u00a7l✖ NÃO\u00a7r usar outros idiomas no chat global, apenas inglês",
-    "modernbeta.rules.5": "\u00a7c\u00a7l✖ NÃO\u00a7r utilizar exploits de duplicação (exceto para areia/gravilha utilizando pistões)",
-    "modernbeta.rules.6": "\u00a7c\u00a7l✖ NÃO\u00a7r fazer comentários sexuais, racistas, sexistas, homofóbicos, etc.",
-    "modernbeta.rules.7": "\u00a7c\u00a7l✖ NÃO\u00a7r discutir eventos REAIS de guerra, drogas, política ou religião, nem fazer construções relacionadas com esses temas",
-    "modernbeta.rules.8": "\u00a7a\u00a7l✔ SIM\u00a7r usa o bom senso e faz amigos ❤",
-    "modernbeta.rules.9": "\u00a7a\u00a7l✔ SIM\u00a7r deixa a vida real à porta e aproveita o jogo dos blocos ❤",
-    
     "attribute.modifier.equals.0": "",
     "attribute.modifier.equals.1": "",
     "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/pt_PT.json
+++ b/java/1_20_6/assets/minecraft/lang/pt_PT.json
@@ -1,14 +1,4 @@
 {
-    "modernbeta.rules.1": "\u00a7c\u00a7l✖ NÃO\u00a7r utilizar hacks ou raio-x",
-    "modernbeta.rules.2": "\u00a7c\u00a7l✖ NÃO\u00a7r destruir ou danificar as construções de outros jogadores",
-    "modernbeta.rules.3": "\u00a7c\u00a7l✖ NÃO\u00a7r roubar itens de baús que não estejam marcados como públicos",
-    "modernbeta.rules.4": "\u00a7c\u00a7l✖ NÃO\u00a7r usar outros idiomas no chat global, apenas inglês",
-    "modernbeta.rules.5": "\u00a7c\u00a7l✖ NÃO\u00a7r utilizar exploits de duplicação (exceto para areia/gravilha utilizando pistões)",
-    "modernbeta.rules.6": "\u00a7c\u00a7l✖ NÃO\u00a7r fazer comentários sexuais, racistas, sexistas, homofóbicos, etc.",
-    "modernbeta.rules.7": "\u00a7c\u00a7l✖ NÃO\u00a7r discutir eventos REAIS de guerra, drogas, política ou religião, nem fazer construções relacionadas com esses temas",
-    "modernbeta.rules.8": "\u00a7a\u00a7l✔ SIM\u00a7r usa o bom senso e faz amigos ❤",
-    "modernbeta.rules.9": "\u00a7a\u00a7l✔ SIM\u00a7r deixa a vida real à porta e aproveita o jogo dos blocos ❤",
-    
     "attribute.modifier.equals.0": "",
     "attribute.modifier.equals.1": "",
     "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/ru_ru.json
+++ b/java/1_20_6/assets/minecraft/lang/ru_ru.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/sk_sk.json
+++ b/java/1_20_6/assets/minecraft/lang/sk_sk.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/sv_se.json
+++ b/java/1_20_6/assets/minecraft/lang/sv_se.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/tr_tr.json
+++ b/java/1_20_6/assets/minecraft/lang/tr_tr.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/uk_ua.json
+++ b/java/1_20_6/assets/minecraft/lang/uk_ua.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/zh_cn.json
+++ b/java/1_20_6/assets/minecraft/lang/zh_cn.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",

--- a/java/1_20_6/assets/minecraft/lang/zh_tw.json
+++ b/java/1_20_6/assets/minecraft/lang/zh_tw.json
@@ -1,14 +1,4 @@
 {
-  "modernbeta.rules.1": "\u00a7c\u00a7l✖ NO\u00a7r hacking or xraying",
-  "modernbeta.rules.2": "\u00a7c\u00a7l✖ NO\u00a7r destroying other's homes/things",
-  "modernbeta.rules.3": "\u00a7c\u00a7l✖ NO\u00a7r stealing from chests that aren't marked as public",
-  "modernbeta.rules.4": "\u00a7c\u00a7l✖ NO\u00a7r languages besides english in global chats",
-  "modernbeta.rules.5": "\u00a7c\u00a7l✖ NO\u00a7r duplication exploits (except sand/gravel using pistons)",
-  "modernbeta.rules.6": "\u00a7c\u00a7l✖ NO\u00a7r over sexual comments, racism, sexism, homophobia, etc.",
-  "modernbeta.rules.7": "\u00a7c\u00a7l✖ NO\u00a7r REAL war/drug/political/religious discussions or builds",
-  "modernbeta.rules.8": "\u00a7a\u00a7l✔ DO\u00a7r use common sense and make some friends ❤",
-  "modernbeta.rules.9": "\u00a7a\u00a7l✔ DO\u00a7r keep real life at the door and enjoy block game ❤",
-  
   "attribute.modifier.equals.0": "",
   "attribute.modifier.equals.1": "",
   "attribute.modifier.equals.2": "",


### PR DESCRIPTION
Removes the rule text from all lang files in the Java resource packs. These are unused and will be replaced by server-sent localized rules in the future (Karltroid, [#computer-science](https://discord.com/channels/1213675813224972328/1316394163255640064/1341987202770538559))
