### PR TITLE
Make first person handheld (tools) more accurate

### DIFF
--- a/java/assets/minecraft/models/item/bow.json
+++ b/java/assets/minecraft/models/item/bow.json
@@ -1,28 +1,28 @@
 {
-	"credit": "Made with Blockbench",
-	"parent": "minecraft:item/generated",
-	"textures": {
-		"particle": "block/tripwire",
-		"layer0": "item/bow"
-	},
-	"display": {
-		"thirdperson_righthand": {
-			"translation": [0, 3, 1],
-			"scale": [0.55, 0.55, 0.55]
-		},
-		"thirdperson_lefthand": {
-			"translation": [0, 3, 1],
-			"scale": [0.55, 0.55, 0.55]
-		},
-		"firstperson_righthand": {
-			"rotation": [0, -90, 25],
-			"translation": [1.13, 3.2, 1.13],
-			"scale": [0.68, 0.68, 0.68]
-		},
-		"firstperson_lefthand": {
-			"rotation": [-120, -90, 25],
-			"translation": [1.13, 3.2, 1.13],
-			"scale": [0.68, 0.68, 0.68]
-		}
-	}
+  "credit": "Made with Blockbench",
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "particle": "block/tripwire",
+    "layer0": "item/bow"
+  },
+  "display": {
+    "thirdperson_righthand": {
+      "translation": [0, 3, 1],
+      "scale": [0.55, 0.55, 0.55]
+    },
+    "thirdperson_lefthand": {
+      "translation": [0, 3, 1],
+      "scale": [0.55, 0.55, 0.55]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, -85, 25],
+      "translation": [1, 3.05, 0.8],
+      "scale": [0.68, 0.68, 0.68]
+    },
+    "firstperson_lefthand": {
+      "rotation": [-120, -90, 25],
+      "translation": [1.13, 3.2, 1.13],
+      "scale": [0.68, 0.68, 0.68]
+    }
+  }
 }

--- a/java/assets/minecraft/models/item/fishing_rod.json
+++ b/java/assets/minecraft/models/item/fishing_rod.json
@@ -1,7 +1,10 @@
 {
-    "parent": "item/handheld_rod",
-    "textures": {
-        "particle": "block/tripwire",
-        "layer0": "item/fishing_rod"
-    }
+  "parent": "item/handheld_rod",
+  "textures": {
+    "particle": "block/tripwire",
+    "layer0": "item/fishing_rod"
+  },
+  "overrides": [
+    { "predicate": { "cast": 1 }, "model": "item/fishing_rod_cast" }
+  ]
 }

--- a/java/assets/minecraft/models/item/handheld.json
+++ b/java/assets/minecraft/models/item/handheld.json
@@ -1,25 +1,15 @@
 {
-    "parent": "item/generated",
-    "display": {
-        "thirdperson_righthand": {
-            "rotation": [ 0, -90, 25 ],
-            "translation": [ 0, 2.5, 2.5 ],
-            "scale": [ 0.85, 0.85, 0.85 ]
-        },
-        "thirdperson_lefthand": {
-            "rotation": [ 0, 90, -25 ],
-            "translation": [ 0, 2.5, 2.5 ],
-            "scale": [ 0.85, 0.85, 0.85 ]
-        },
-        "firstperson_righthand": {
-            "rotation": [ 0, -90, 25 ],
-            "translation": [ 1.13, 3.2, 1.13 ],
-            "scale": [ 0.68, 0.68, 0.68 ]
-        },
-        "firstperson_lefthand": {
-            "rotation": [ 0, 90, -25 ],
-            "translation": [ 1.13, 3.2, 1.13 ],
-            "scale": [ 0.68, 0.68, 0.68 ]
-        }
+  "parent": "item/generated",
+  "display": {
+    "thirdperson_righthand": {
+      "rotation": [0, -90, 25],
+      "translation": [0, 2.5, 2.5],
+      "scale": [0.85, 0.85, 0.85]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, -85, 25],
+      "translation": [1, 3.05, 0.8],
+      "scale": [0.68, 0.68, 0.68]
     }
+  }
 }


### PR DESCRIPTION
Makes first person tool view model more accurate to beta. 

Before overlay:
<img width="1086" height="618" alt="image" src="https://github.com/user-attachments/assets/7bbc4108-113c-4417-9aa5-2c6310b27382" />

After overlay:
<img width="1092" height="624" alt="image" src="https://github.com/user-attachments/assets/02b5d589-7910-4748-85a8-932dee1d4b3f" />
